### PR TITLE
Better shims PATH addition to shell

### DIFF
--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -26,15 +26,3 @@ Direnv and rtx work similarly and there should be a direnv extension that can be
 
 Alternatively, you may be able to get tighter integration with a direnv extension and using the
 [`use_rtx`](/direnv) direnv function.
-
-pathmunge() {
-  if ! echo "${PATH}" | /usr/bin/grep -E -q "(^|:)$1($|:)"; then
-    if [ "$2" = "after" ]; then
-      PATH=${PATH}:$1
-    else
-      PATH=$1:${PATH}
-    fi
-  fi
-}
-
-pathmunge ~/.local/share/rtx/shims

--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -3,11 +3,20 @@
 IDEs work better with shims than they do environment variable modifications. The simplest way is
 to add the rtx shim directory to PATH.
 
-For IntelliJ and VSCode—and likely others, you can modify `~/.zprofile`
-with the following:
+For IntelliJ and VSCode—and likely others, you can modify `~/.zprofile` if your are using zsh or `~/.bashrc` if you are using bash with the following:
 
 ```sh
-export PATH="$HOME/.local/share/rtx/shims:$PATH"
+pathmunge() {
+  if ! echo "${PATH}" | /usr/bin/grep -E -q "(^|:)$1($|:)"; then
+    if [ "$2" = "after" ]; then
+      PATH=${PATH}:$1
+    else
+      PATH=$1:${PATH}
+    fi
+  fi
+}
+
+pathmunge ~/.local/share/rtx/shims
 ```
 
 This won't work for all of rtx's functionality. For example, arbitrary env vars in `[env]` will only be set
@@ -17,3 +26,15 @@ Direnv and rtx work similarly and there should be a direnv extension that can be
 
 Alternatively, you may be able to get tighter integration with a direnv extension and using the
 [`use_rtx`](/direnv) direnv function.
+
+pathmunge() {
+  if ! echo "${PATH}" | /usr/bin/grep -E -q "(^|:)$1($|:)"; then
+    if [ "$2" = "after" ]; then
+      PATH=${PATH}:$1
+    else
+      PATH=$1:${PATH}
+    fi
+  fi
+}
+
+pathmunge ~/.local/share/rtx/shims


### PR DESCRIPTION
This little modification ensure shims PATH is added only one time even if you are using sub-shell or calling a shell from another (makefile or other process can have this behavior) :

Example with bash without this tricks :
```
jylenhof@pcportablejyl:~$ echo $SHELL
/bin/bash
jylenhof@pcportablejyl:~$ echo $SHLVL
1
jylenhof@pcportablejyl:~$ echo $PATH
/home/jylenhof/.local/share/rtx/shims:/home/jylenhof/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
jylenhof@pcportablejyl:~$ bash
jylenhof@pcportablejyl:~$ echo $SHELL
/bin/bash
jylenhof@pcportablejyl:~$ echo $SHLVL
2
jylenhof@pcportablejyl:~$ echo $PATH
/home/jylenhof/.local/share/rtx/shims:/home/jylenhof/.local/share/rtx/shims:/home/jylenhof/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
jylenhof@pcportablejyl:~$ 

```

Example with bash with this tricks :
```
jylenhof@pcportablejyl:~$ echo $SHELL
/bin/bash
jylenhof@pcportablejyl:~$ echo $SHLVL
1
jylenhof@pcportablejyl:~$ echo $PATH
/home/jylenhof/.local/share/rtx/shims:/home/jylenhof/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
jylenhof@pcportablejyl:~$ bash
jylenhof@pcportablejyl:~$ echo $SHELL
/bin/bash
jylenhof@pcportablejyl:~$ echo $SHLVL
2
jylenhof@pcportablejyl:~$ echo $PATH
/home/jylenhof/.local/share/rtx/shims:/home/jylenhof/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
jylenhof@pcportablejyl:~$ 

```